### PR TITLE
New tests for different sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Turtle Canon
 
-*It's turtles all the way down.*
+<!-- markdownlint-disable-next-line MD036 -->
+*It's turtles all the way down*
 
 [![Codecov main](https://img.shields.io/codecov/c/github/CasperWA/turtle-canon/main)](https://app.codecov.io/gh/CasperWA/turtle-canon)
 [![CI main](https://github.com/CasperWA/turtle-canon/actions/workflows/ci_tests.yml/badge.svg?branch=main)](https://github.com/CasperWA/turtle-canon/actions/workflows/ci_tests.yml?query=branch%3Amain)
@@ -15,7 +16,7 @@ The main use case for developing this tool is when developing ontologies utilizi
 
 ## Install
 
-The tool is written in Python 3.9, so one needs a Python 3.9 interpreter to run it at this stage.
+The tool is written for Python 3.9, so one needs at minimum Python 3.9 installed to run it at this stage.
 The plan is to make a stand-alone executable for each of the major OS'.
 
 Install via PyPI (stable version, recommended):

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,23 @@
+# Design outline
+
+As outlined on the landing page, the goal of the Turtle Canon tool is to canonize (or standardize) the Turtle ontology files exported by, especially, [Protégé](https://protege.stanford.edu/).
+
+To achieve this, [RDFlib](https://rdflib.readthedocs.io/) is utilized to load in the Turtle file as a `rdflib.Graph` object, retrieving all the triples, sorting them, creating an empty, new `rdflib.Graph` object, add the sorted list of triples, and then export the ontology as a Turtle file, overwriting the original Turtle file.
+
+In this process, precautions are taken to ensure the Turtle file is *only* overwritten if everything has gone as expected and an extensive validation of the input Turtle file is undertaken before even parsing it as a `rdflib.Graph` object.
+
+## Same ontology - different generation tools
+
+For the use case of having the same ontology, but in a logically different state, e.g., when triples may be added upon reasoning an ontology, but it is still considered to be the same ontology, the canonization process falters.
+It falters in the sense that Turtle Canon considers the provided list of triples to be the ultimate source of truth for canonization.
+Turtle Canon will **not** try to reason or infer what set of triples have been added during a reasoning process, and which were the "original".
+It will instead merely retrieve the list of triples, sort them, and export them as a Turtle file, overwriting the source Turtle file.
+
+### `diff` tool
+
+It is the intention to add a `diff`-like tool for these events, where the differing set of triples are listed when comparing two Turtle files.
+
+From there, adding functionality to interactively manipulate which triples should be created or removed should be somewhat straight-forward.
+The intention is to add exactly this, however, the exact design for this has not yet been determined.
+
+The initial point of this tool is to help users be aware that changes have occurred between two ontologies, what they are, and understand whether they are semantic or logical.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 # Turtle Canon
 
-*It's turtles all the way down.*
+<!-- markdownlint-disable-next-line MD036 -->
+*It's turtles all the way down*
 
 [![Codecov main](https://img.shields.io/codecov/c/github/CasperWA/turtle-canon/main)](https://app.codecov.io/gh/CasperWA/turtle-canon)
 [![CI main](https://github.com/CasperWA/turtle-canon/actions/workflows/ci_tests.yml/badge.svg?branch=main)](https://github.com/CasperWA/turtle-canon/actions/workflows/ci_tests.yml?query=branch%3Amain)
@@ -15,7 +16,7 @@ The main use case for developing this tool is when developing ontologies utilizi
 
 ## Install
 
-The tool is written in Python 3.9, so one needs a Python 3.9 interpreter to run it at this stage.
+The tool is written for Python 3.9, so one needs at minimum Python 3.9 installed to run it at this stage.
 The plan is to make a stand-alone executable for each of the major OS'.
 
 Install via PyPI (stable version, recommended):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,3 +77,32 @@ def tmp_dir() -> Path:
             f"Failed to remove temporary directory at {tmpdir.name}. "
             f"Content:\n{os.listdir(tmpdir.name)}"
         )
+
+
+@pytest.fixture
+def different_sources_ontologies(top_dir: Path) -> "List[Path]":
+    """Yield list of Turtle files generated using different tools, i.e., coming from
+    different sources."""
+    import os
+    from shutil import copy
+    from tempfile import TemporaryDirectory
+
+    turtle_files = list(
+        (top_dir / "tests" / "static" / "different_sources").glob(
+            "turtle_canon_tests*.ttl"
+        )
+    )
+    tmpdir = TemporaryDirectory()
+    tmpdir_path = Path(tmpdir.name)
+    try:
+        res = []
+        for turtle_file in turtle_files:
+            copy(turtle_file, tmpdir_path / turtle_file.name)
+            res.append(tmpdir_path / turtle_file.name)
+        yield res
+    finally:
+        tmpdir.cleanup()
+        assert not Path(tmpdir.name).exists(), (
+            f"Failed to remove temporary directory at {tmpdir.name}. "
+            f"Content:\n{os.listdir(tmpdir.name)}"
+        )

--- a/tests/static/different_sources/turtle_canon_tests_EMMOntoPy.ttl
+++ b/tests/static/different_sources/turtle_canon_tests_EMMOntoPy.ttl
@@ -1,0 +1,116 @@
+@prefix : <http://emmo.info/emmo/domain/onto#> .
+@prefix core: <http://www.w3.org/2004/02/skos/core#> .
+@prefix emmo: <http://emmo.info/emmo#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix term: <http://purl.org/dc/terms/> .
+
+<http://emmo.info/emmo/domain/onto> a owl:Ontology ;
+    term:creator "Astrid Marthinsen"@en,
+        "Georg Schmidt"@en,
+        "Jesper Friis"@en,
+        "Sylvain Gouttebroze"@en,
+        "Tomas Manik"@en,
+        "Ulrike Cihak-Bayr"@en ;
+    owl:imports <https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta/emmo-inferred-chemistry> .
+
+:EMMO_0264be35-e8ad-5b35-a1a3-84b37bde22d1 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Temporal pattern occurring in a time interval"@en ;
+    emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Light house during one night"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_e1097637_70d2_4895_973f_2396f04fa204 ;
+            owl:someValuesFrom emmo:EMMO_d4f7d378_5e3b_468a_baa1_a7e98358cda7 ],
+        [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+            owl:someValuesFrom :EMMO_b41c9cb3-3b2d-509f-9c93-aa04da134307 ],
+        :EMMO_138590b8-3333-515d-87ab-717aac8434e6,
+        :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8 ;
+    core:prefLabel "FiniteTemporalPattern"@en .
+
+:EMMO_70269d17-fbaa-54a6-8905-ce4dee45e0dd a owl:Class ;
+    rdfs:subClassOf emmo:EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf ;
+    core:prefLabel "Particle"@en .
+
+:EMMO_76b2eb15-3ab7-52b3-ade2-755aa390d63e a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Spatial pattern localized in a volume of space"@en ;
+    emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Textured surface after etching"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_e1097637_70d2_4895_973f_2396f04fa204 ;
+            owl:someValuesFrom emmo:EMMO_f1a51559_aa3d_43a0_9327_918039f0dfed ],
+        [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+            owl:someValuesFrom :EMMO_472ed27e-ce08-53cb-8453-56ab363275c4 ],
+        :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8,
+        :EMMO_5f50f77e-f321-53e3-af76-fe5b0a347479 ;
+    core:prefLabel "FiniteSpatialPattern"@en .
+
+:EMMO_903bf818-c0b4-56ef-9673-799ba204795d a owl:Class ;
+    rdfs:subClassOf emmo:EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf ;
+    core:prefLabel "Precipitate"@en .
+
+:EMMO_b04965e6-a9bb-591f-8f8a-1adcb2c8dc39 a owl:Class ;
+    rdfs:subClassOf emmo:EMMO_21f56795_ee72_4858_b571_11cfaa59c1a8 ;
+    core:prefLabel "1"@en .
+
+:EMMO_b0f0e57e-464d-562f-80ec-b216c92d5e88 a owl:Class ;
+    rdfs:subClassOf emmo:EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf ;
+    core:prefLabel "Grain"@en .
+
+:EMMO_d35b8f2a-64c0-5f57-a569-308bc8f8a1c5 a owl:Class ;
+    rdfs:subClassOf emmo:EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf ;
+    core:prefLabel "Phase"@en .
+
+:EMMO_e0b20a22-7e6f-5c81-beca-35bc5358e11b a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+    rdfs:subClassOf :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8,
+        :EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 ;
+    core:prefLabel "FiniteSpatioTemporalPattern"@en .
+
+:EMMO_138590b8-3333-515d-87ab-717aac8434e6 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Pattern with only temporal aspect"@en ;
+    emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Voltage in AC plug"@en ;
+    rdfs:subClassOf :EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 ;
+    core:prefLabel "TemporalPattern"@en .
+
+:EMMO_472ed27e-ce08-53cb-8453-56ab363275c4 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+    rdfs:subClassOf :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 ;
+    core:prefLabel "SpatialBoundary"@en .
+
+:EMMO_5f50f77e-f321-53e3-af76-fe5b0a347479 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Spatial pattern without regular temporal variations"@en ;
+    emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Infinite grid"@en ;
+    rdfs:subClassOf :EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 ;
+    core:prefLabel "SpatialPattern"@en .
+
+:EMMO_b41c9cb3-3b2d-509f-9c93-aa04da134307 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+    rdfs:subClassOf :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 ;
+    core:prefLabel "TemporalBoundary"@en .
+
+:EMMO_cd254842-c697-55f6-917d-9805c77b9187 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "everything that can be perceived or measured"@en ;
+    rdfs:comment " this definition is much broader than definition of pattern such as \"the regular and repeated way in which something happens or is\""@en,
+        "a pattern is defined from a contrast"@en ;
+    rdfs:subClassOf emmo:EMMO_649bf97b_4397_4005_90d9_219755d92e34 ;
+    core:prefLabel "Pattern"@en .
+
+:EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+    rdfs:subClassOf emmo:EMMO_649bf97b_4397_4005_90d9_219755d92e34 ;
+    core:prefLabel "Boundary"@en .
+
+:EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Pattern occuring within a boundary in the 4D space"@en ;
+    rdfs:comment "Every physical patterns are FinitePattern"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+            owl:someValuesFrom :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 ],
+        :EMMO_cd254842-c697-55f6-917d-9805c77b9187 ;
+    core:prefLabel "FinitePattern"@en .
+
+:EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+    rdfs:subClassOf :EMMO_cd254842-c697-55f6-917d-9805c77b9187 ;
+    core:prefLabel "SpatioTemporalPattern"@en .
+

--- a/tests/static/different_sources/turtle_canon_tests_Protege.ttl
+++ b/tests/static/different_sources/turtle_canon_tests_Protege.ttl
@@ -1,0 +1,214 @@
+@prefix : <http://emmo.info/emmo/domain/onto#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix core: <http://www.w3.org/2004/02/skos/core#> .
+@prefix emmo: <http://emmo.info/emmo#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix term: <http://purl.org/dc/terms/> .
+@base <http://emmo.info/emmo/domain/onto> .
+
+<http://emmo.info/emmo/domain/onto> rdf:type owl:Ontology ;
+                                     owl:imports <https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta/emmo-inferred-chemistry> ;
+                                     term:creator "Astrid Marthinsen"@en ,
+                                                  "Georg Schmidt"@en ,
+                                                  "Jesper Friis"@en ,
+                                                  "Sylvain Gouttebroze"@en ,
+                                                  "Tomas Manik"@en ,
+                                                  "Ulrike Cihak-Bayr"@en .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://emmo.info/emmo#EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9
+emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 rdf:type owl:AnnotationProperty .
+
+
+###  http://emmo.info/emmo#EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a
+emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/creator
+term:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#prefLabel
+core:prefLabel rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://emmo.info/emmo#EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f
+emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f rdf:type owl:ObjectProperty .
+
+
+###  http://emmo.info/emmo#EMMO_e1097637_70d2_4895_973f_2396f04fa204
+emmo:EMMO_e1097637_70d2_4895_973f_2396f04fa204 rdf:type owl:ObjectProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://emmo.info/emmo#EMMO_21f56795_ee72_4858_b571_11cfaa59c1a8
+emmo:EMMO_21f56795_ee72_4858_b571_11cfaa59c1a8 rdf:type owl:Class .
+
+
+###  http://emmo.info/emmo#EMMO_649bf97b_4397_4005_90d9_219755d92e34
+emmo:EMMO_649bf97b_4397_4005_90d9_219755d92e34 rdf:type owl:Class .
+
+
+###  http://emmo.info/emmo#EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf
+emmo:EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf rdf:type owl:Class .
+
+
+###  http://emmo.info/emmo#EMMO_d4f7d378_5e3b_468a_baa1_a7e98358cda7
+emmo:EMMO_d4f7d378_5e3b_468a_baa1_a7e98358cda7 rdf:type owl:Class .
+
+
+###  http://emmo.info/emmo#EMMO_f1a51559_aa3d_43a0_9327_918039f0dfed
+emmo:EMMO_f1a51559_aa3d_43a0_9327_918039f0dfed rdf:type owl:Class .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_0264be35-e8ad-5b35-a1a3-84b37bde22d1
+:EMMO_0264be35-e8ad-5b35-a1a3-84b37bde22d1 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_138590b8-3333-515d-87ab-717aac8434e6 ,
+                                                           :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8 ,
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+                                                             owl:someValuesFrom :EMMO_b41c9cb3-3b2d-509f-9c93-aa04da134307
+                                                           ] ,
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty emmo:EMMO_e1097637_70d2_4895_973f_2396f04fa204 ;
+                                                             owl:someValuesFrom emmo:EMMO_d4f7d378_5e3b_468a_baa1_a7e98358cda7
+                                                           ] ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Temporal pattern occurring in a time interval"@en ;
+                                           emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Light house during one night"@en ;
+                                           core:prefLabel "FiniteTemporalPattern"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_138590b8-3333-515d-87ab-717aac8434e6
+:EMMO_138590b8-3333-515d-87ab-717aac8434e6 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Pattern with only temporal aspect"@en ;
+                                           emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Voltage in AC plug"@en ;
+                                           core:prefLabel "TemporalPattern"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3
+:EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 rdf:type owl:Class ;
+                                           rdfs:subClassOf emmo:EMMO_649bf97b_4397_4005_90d9_219755d92e34 ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+                                           core:prefLabel "Boundary"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_472ed27e-ce08-53cb-8453-56ab363275c4
+:EMMO_472ed27e-ce08-53cb-8453-56ab363275c4 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+                                           core:prefLabel "SpatialBoundary"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8
+:EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_cd254842-c697-55f6-917d-9805c77b9187 ,
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+                                                             owl:someValuesFrom :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3
+                                                           ] ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Pattern occuring within a boundary in the 4D space"@en ;
+                                           rdfs:comment "Every physical patterns are FinitePattern"@en ;
+                                           core:prefLabel "FinitePattern"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_5f50f77e-f321-53e3-af76-fe5b0a347479
+:EMMO_5f50f77e-f321-53e3-af76-fe5b0a347479 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Spatial pattern without regular temporal variations"@en ;
+                                           emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Infinite grid"@en ;
+                                           core:prefLabel "SpatialPattern"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_70269d17-fbaa-54a6-8905-ce4dee45e0dd
+:EMMO_70269d17-fbaa-54a6-8905-ce4dee45e0dd rdf:type owl:Class ;
+                                           rdfs:subClassOf emmo:EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf ;
+                                           core:prefLabel "Particle"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_76b2eb15-3ab7-52b3-ade2-755aa390d63e
+:EMMO_76b2eb15-3ab7-52b3-ade2-755aa390d63e rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8 ,
+                                                           :EMMO_5f50f77e-f321-53e3-af76-fe5b0a347479 ,
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+                                                             owl:someValuesFrom :EMMO_472ed27e-ce08-53cb-8453-56ab363275c4
+                                                           ] ,
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty emmo:EMMO_e1097637_70d2_4895_973f_2396f04fa204 ;
+                                                             owl:someValuesFrom emmo:EMMO_f1a51559_aa3d_43a0_9327_918039f0dfed
+                                                           ] ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Spatial pattern localized in a volume of space"@en ;
+                                           emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Textured surface after etching"@en ;
+                                           core:prefLabel "FiniteSpatialPattern"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_903bf818-c0b4-56ef-9673-799ba204795d
+:EMMO_903bf818-c0b4-56ef-9673-799ba204795d rdf:type owl:Class ;
+                                           rdfs:subClassOf emmo:EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf ;
+                                           core:prefLabel "Precipitate"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890
+:EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_cd254842-c697-55f6-917d-9805c77b9187 ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+                                           core:prefLabel "SpatioTemporalPattern"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_b04965e6-a9bb-591f-8f8a-1adcb2c8dc39
+:EMMO_b04965e6-a9bb-591f-8f8a-1adcb2c8dc39 rdf:type owl:Class ;
+                                           rdfs:subClassOf emmo:EMMO_21f56795_ee72_4858_b571_11cfaa59c1a8 ;
+                                           core:prefLabel "1"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_b0f0e57e-464d-562f-80ec-b216c92d5e88
+:EMMO_b0f0e57e-464d-562f-80ec-b216c92d5e88 rdf:type owl:Class ;
+                                           rdfs:subClassOf emmo:EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf ;
+                                           core:prefLabel "Grain"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_b41c9cb3-3b2d-509f-9c93-aa04da134307
+:EMMO_b41c9cb3-3b2d-509f-9c93-aa04da134307 rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+                                           core:prefLabel "TemporalBoundary"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_cd254842-c697-55f6-917d-9805c77b9187
+:EMMO_cd254842-c697-55f6-917d-9805c77b9187 rdf:type owl:Class ;
+                                           rdfs:subClassOf emmo:EMMO_649bf97b_4397_4005_90d9_219755d92e34 ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "everything that can be perceived or measured"@en ;
+                                           rdfs:comment " this definition is much broader than definition of pattern such as \"the regular and repeated way in which something happens or is\""@en ,
+                                                        "a pattern is defined from a contrast"@en ;
+                                           core:prefLabel "Pattern"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_d35b8f2a-64c0-5f57-a569-308bc8f8a1c5
+:EMMO_d35b8f2a-64c0-5f57-a569-308bc8f8a1c5 rdf:type owl:Class ;
+                                           rdfs:subClassOf emmo:EMMO_802d3e92_8770_4f98_a289_ccaaab7fdddf ;
+                                           core:prefLabel "Phase"@en .
+
+
+###  http://emmo.info/emmo/domain/onto#EMMO_e0b20a22-7e6f-5c81-beca-35bc5358e11b
+:EMMO_e0b20a22-7e6f-5c81-beca-35bc5358e11b rdf:type owl:Class ;
+                                           rdfs:subClassOf :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8 ,
+                                                           :EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 ;
+                                           emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+                                           core:prefLabel "FiniteSpatioTemporalPattern"@en .
+
+
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/tests/test_turtle_canon.py
+++ b/tests/test_turtle_canon.py
@@ -201,3 +201,26 @@ def test_extra_whitespace(simple_turtle_file: Path) -> None:
         assert (
             changes.read_text(encoding="utf8") == original_canonized_content
         ), assertion_fail_msg
+
+
+def test_different_sources(different_sources_ontologies: "List[Path]") -> None:
+    """Test that the canonization is true only to the given set of triples."""
+    import re
+
+    from turtle_canon.canon import canonize
+
+    source_regex = r"^turtle_canon_tests_(?P<source>.*)\.ttl$"
+
+    for turtle_file in different_sources_ontologies:
+        source_match = re.match(source_regex, turtle_file.name)
+        if source_match:
+            source = source_match.group("source")
+        else:
+            pytest.fail(f"Couldn't determine source from {turtle_file.name!r} !")
+
+        try:
+            canonize(turtle_file)
+        except Exception as exc:
+            pytest.fail(
+                f"Failed canonizing file from source {source}.\n\nException:\n{exc}"
+            )


### PR DESCRIPTION
Adds test Turtle files generated from different sources, in this case [EMMOntoPy](https://github.com/emmo-repo/EMMO-python) and [Protégé](https://protege.stanford.edu/).
They are then canonized and should return the same result - however, at the moment this is **not** the case, as the Protégé-generated ontology has added more triples to the Turtle file than what was originally in the file generated by EMMOntoPy.

~**Note**: This branch is based on the branch related to #14.~