### PR TITLE
Support multiple files for CLI + add `--fail-fast` option

### DIFF
--- a/tests/cli/test_cmd_turtle_canon.py
+++ b/tests/cli/test_cmd_turtle_canon.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from subprocess import CalledProcessError, CompletedProcess
-    from typing import Union
+    from typing import List, Union
 
     from .conftest import CLIOutput, CLIRunner
 
@@ -97,3 +97,19 @@ def test_empty_file(clirunner: "CLIRunner", tmp_dir: Path) -> None:
     ), assertion_help
     assert output.returncode == 0
     assert "WARNING" in output.stderr, assertion_help
+
+
+def test_multiple_files(
+    clirunner: "CLIRunner", single_turtle_permutations: "List[Path]"
+) -> None:
+    """Ensure passing multiple files to the CLI works."""
+    output: "CLIRunnerOutput" = clirunner([str(_) for _ in single_turtle_permutations])
+
+    assertion_help = (
+        f"STDOUT: {output.stdout}\nSTDERR: {output.stderr}\nRETURN_CODE: "
+        f"{output.returncode}"
+    )
+
+    assert not output.stderr, assertion_help
+    assert not output.stderr, assertion_help
+    assert output.returncode == 0

--- a/tests/cli/test_cmd_turtle_canon.py
+++ b/tests/cli/test_cmd_turtle_canon.py
@@ -23,9 +23,15 @@ def test_absolute_path(clirunner: "CLIRunner", simple_turtle_file: Path) -> None
     """Simple test run with minimalistic Turtle file."""
     output: "CLIRunnerOutput" = clirunner([str(simple_turtle_file)])
 
-    assert (
-        output.stdout == output.stderr == ""
-    ), f"STDOUT: {output.stdout}\nSTDERR: {output.stderr}"
+    assertion_help = (
+        f"STDOUT: {output.stdout}\nSTDERR: {output.stderr}\nRETURN_CODE: "
+        f"{output.returncode}"
+    )
+
+    assert not output.stderr, assertion_help
+    assert output.stdout, assertion_help
+    assert output.returncode == 0, assertion_help
+    assert "Successful" in output.stdout, assertion_help
 
 
 def test_relative_path(clirunner: "CLIRunner", simple_turtle_file: Path) -> None:
@@ -38,9 +44,15 @@ def test_relative_path(clirunner: "CLIRunner", simple_turtle_file: Path) -> None
 
     output: "CLIRunnerOutput" = clirunner([str(relative_path)], run_dir="/tmp")
 
-    assert (
-        output.stdout == output.stderr == ""
-    ), f"STDOUT: {output.stdout}\nSTDERR: {output.stderr}"
+    assertion_help = (
+        f"STDOUT: {output.stdout}\nSTDERR: {output.stderr}\nRETURN_CODE: "
+        f"{output.returncode}"
+    )
+
+    assert not output.stderr, assertion_help
+    assert output.stdout, assertion_help
+    assert output.returncode == 0, assertion_help
+    assert "Successful" in output.stdout, assertion_help
 
 
 def test_non_existant_file(clirunner: "CLIRunner") -> None:
@@ -68,12 +80,13 @@ def test_non_existant_file(clirunner: "CLIRunner") -> None:
     ), assertion_help
     assert output.returncode == 1, assertion_help
     assert "ERROR" in output.stderr, assertion_help
+    assert "Successful" not in output.stdout, assertion_help
 
 
 def test_empty_file(clirunner: "CLIRunner", tmp_dir: Path) -> None:
     """Ensure a warning is printed with error code != 0 if the passed file does not
     exist."""
-    empty_file = tmp_dir / "non-existant.ttl"
+    empty_file = tmp_dir / "empty.ttl"
     empty_file.touch()
     assert (
         empty_file.exists()
@@ -97,6 +110,7 @@ def test_empty_file(clirunner: "CLIRunner", tmp_dir: Path) -> None:
     ), assertion_help
     assert output.returncode == 0
     assert "WARNING" in output.stderr, assertion_help
+    assert "Successful" not in output.stdout, assertion_help
 
 
 def test_multiple_files(
@@ -113,3 +127,71 @@ def test_multiple_files(
     assert not output.stderr, assertion_help
     assert not output.stderr, assertion_help
     assert output.returncode == 0
+    assert "Successful" in output.stdout, assertion_help
+
+
+def test_fail_fast(
+    clirunner: "CLIRunner", single_turtle_permutations: "List[Path]", tmp_dir: Path
+) -> None:
+    """Test `--fail-fast`."""
+    warning_file = tmp_dir / "empty.ttl"
+    warning_file.touch()
+    assert (
+        warning_file.exists()
+    ), f"{warning_file} was expected to exist, but suprisingly it does not !"
+    assert (
+        warning_file.read_text() == ""
+    ), f"{warning_file} was expected to be empty, but suprisingly it is not !"
+
+    error_file = tmp_dir / "non_existant.ttl"
+    assert (
+        not error_file.exists()
+    ), f"{error_file} was expected to not exist, but suprisingly it does !"
+
+    assert len(single_turtle_permutations) == 3
+
+    single_turtle_permutations.insert(1, error_file)
+    single_turtle_permutations.insert(-1, warning_file)
+    single_turtle_permutations.insert(-1, error_file)
+
+    error_substring = f"Supplied file {error_file.absolute()} not found."
+
+    output: "CLIRunnerOutput" = clirunner(
+        [str(_) for _ in single_turtle_permutations],
+        expected_error=error_substring,
+    )
+
+    assertion_help = (
+        f"STDOUT: {output.stdout}\nSTDERR: {output.stderr}\nRETURN_CODE: "
+        f"{output.returncode}"
+    )
+
+    assert output.stderr, assertion_help
+    assert (
+        error_substring in output.stderr and error_substring not in output.stdout
+    ), assertion_help
+    assert output.returncode == 1, assertion_help
+    assert "ERROR" in output.stderr, assertion_help
+    assert "*" in output.stderr, assertion_help
+    assert not output.stdout, assertion_help
+    assert "Successful" not in output.stdout, assertion_help
+
+    output: "CLIRunnerOutput" = clirunner(
+        ["--fail-fast"] + [str(_) for _ in single_turtle_permutations],
+        expected_error=error_substring,
+    )
+
+    assertion_help = (
+        f"STDOUT: {output.stdout}\nSTDERR: {output.stderr}\nRETURN_CODE: "
+        f"{output.returncode}"
+    )
+
+    assert output.stderr, assertion_help
+    assert (
+        error_substring in output.stderr and error_substring not in output.stdout
+    ), assertion_help
+    assert output.returncode == 1, assertion_help
+    assert "ERROR" in output.stderr, assertion_help
+    assert "*" not in output.stderr, assertion_help
+    assert not output.stdout, assertion_help
+    assert "Successful" not in output.stdout, assertion_help

--- a/turtle_canon/cli/cmd_turtle_canon.py
+++ b/turtle_canon/cli/cmd_turtle_canon.py
@@ -42,6 +42,8 @@ def main(args: "List[str]" = None) -> None:
     )
     parser.add_argument(
         "TURTLE_FILE",
+        action="extend",
+        nargs="+",
         type=Path,
         help=(
             "Path to the Turtle file. Can be relative or absolute. Example: "
@@ -52,7 +54,8 @@ def main(args: "List[str]" = None) -> None:
     args: "CLIArgs" = parser.parse_args(args)  # type: ignore[assignment]
 
     try:
-        canonize(turtle_file=args.TURTLE_FILE)
+        for turtle_file in args.TURTLE_FILE:
+            canonize(turtle_file)
     except TurtleCanonException as exception:
         print_error(exception)
     except TurtleCanonWarning as warning:

--- a/turtle_canon/cli/cmd_turtle_canon.py
+++ b/turtle_canon/cli/cmd_turtle_canon.py
@@ -7,10 +7,18 @@ import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections import namedtuple
+    from dataclasses import dataclass
     from typing import List
 
-    CLIArgs = namedtuple("CLIArgs", ["version", "log_level", "TURTLE_FILE"])
+    @dataclass
+    class CLIArgs:
+        """CLI parsed arguments"""
+
+        version: str
+        log_level: str
+        fail_fast: bool
+        turtle_files: List[Path]
+
 
 LOGGING_LEVELS = [logging.getLevelName(level).lower() for level in range(0, 51, 10)]
 
@@ -19,7 +27,7 @@ def main(args: "List[str]" = None) -> None:
     """Turtle Canon - It's turtles all the way down."""
     from turtle_canon import __version__
     from turtle_canon.canon import canonize
-    from turtle_canon.cli.utils import print_error, print_warning
+    from turtle_canon.cli.utils import print_error, print_summary, print_warning
     from turtle_canon.utils.exceptions import TurtleCanonException
     from turtle_canon.utils.warnings import TurtleCanonWarning
 
@@ -41,7 +49,17 @@ def main(args: "List[str]" = None) -> None:
         default="info",
     )
     parser.add_argument(
-        "TURTLE_FILE",
+        "--fail-fast",
+        action="store_true",
+        help=(
+            "Exit the canonization immediately if an error occurs. E.g., if multiple "
+            "files are given, Turtle Canon will exit immediately if an error occurs "
+            "when canonization a single file. Otherwise, all files will be attempted "
+            "to be canonized, and a summary will be printed at the end."
+        ),
+    )
+    parser.add_argument(
+        "turtle_files",
         action="extend",
         nargs="+",
         type=Path,
@@ -49,15 +67,33 @@ def main(args: "List[str]" = None) -> None:
             "Path to the Turtle file. Can be relative or absolute. Example: "
             "'../my_ontology.ttl'."
         ),
+        metavar="TURTLE_FILE",
     )
 
     args: "CLIArgs" = parser.parse_args(args)  # type: ignore[assignment]
 
-    try:
-        for turtle_file in args.TURTLE_FILE:
+    errors = []
+    warnings = []
+
+    number_of_turtle_files = len(args.turtle_files)
+
+    while args.turtle_files:
+        turtle_file = args.turtle_files.pop()
+        try:
             canonize(turtle_file)
-    except TurtleCanonException as exception:
-        print_error(exception)
-    except TurtleCanonWarning as warning:
-        print_warning(warning)
+        except TurtleCanonException as exception:
+            if args.fail_fast:
+                print_error(exception)
+            else:
+                errors.append(exception)
+        except TurtleCanonWarning as warning:
+            if number_of_turtle_files == 1:
+                print_warning(warning)
+            warnings.append(warning)
+
+    if number_of_turtle_files == 1 and warnings:
+        pass
+    else:
+        print_summary(errors=errors, warnings=warnings)
+
     sys.exit()

--- a/turtle_canon/cli/utils.py
+++ b/turtle_canon/cli/utils.py
@@ -3,7 +3,7 @@ import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Optional, TextIO, Union
+    from typing import Optional, Sequence, TextIO, Union
 
 
 def _print_message(
@@ -55,3 +55,44 @@ def print_warning(message: "Union[str, Exception]", exit_after: bool = False) ->
     if isinstance(message, Exception):
         res += f"\n\nGeneral information about the warning: {message.__doc__}"
     _print_message(res, target=sys.stderr, prefix="WARNING: ", exit_after=exit_after)
+
+
+def print_summary(
+    errors: "Optional[Sequence[Union[str, Exception]]]" = None,
+    warnings: "Optional[Sequence[Union[str, Exception]]]" = None,
+    exit_after: bool = True,
+) -> None:
+    """Print a summary, including of error and/or warning messages.
+
+    Parameters:
+        errors: List of error messages.
+        warnings: List of warning messages.
+        exit_after: Whether or not to call `sys.exit(1)` after printing the message.
+
+    """
+    exit_after = bool(errors)
+
+    res = ""
+    target = sys.stdout
+
+    if errors or warnings:
+        res += "The balls are stuck !\n\n"
+        target = sys.stderr
+    else:
+        res += "Successful Fire !"
+
+    if errors:
+        res += "ERRORS:\n"
+        for error in errors:
+            res += f"* {error}\n"
+            if isinstance(error, Exception):
+                res += f"  General info: {error.__doc__}\n"
+
+    if warnings:
+        res += "WARNINGS:\n"
+        for warning in warnings:
+            res += f"* {warning}\n"
+            if isinstance(warning, Exception):
+                res += f"  General info: {warning.__doc__}\n"
+
+    _print_message(res, target=target, prefix="", exit_after=exit_after)


### PR DESCRIPTION
Closes #21 

This adds support for passing multiple Turtle files to the CLI.
At the end a summary is printed.

A new option `--fail-fast` has been added, it's a flag option.
If passed and multiple files are passed, the CLI will exit and print a normal "ERROR" message if an error occurs.

If a single file is passed to the CLI and a warning occurs, the summary is skipped and a normal single WARNING is printed.