### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Fetch PR body
       id: pr_body
-      uses: chuhlomin/render-template@v1.2
+      uses: chuhlomin/render-template@v1.4
       with:
         template: .github/utils/single_dependency_pr_body.txt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
   - id: check-symlinks
   - id: check-yaml
@@ -33,7 +33,7 @@ repos:
     exclude: ^tests/.*$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910-1
+  rev: v0.931
   hooks:
   - id: mypy
     exclude: ^tests/.*$

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -4,4 +4,4 @@ mkdocs~=1.2
 mkdocs-awesome-pages-plugin~=2.6
 mkdocs-material~=8.1
 mkdocs-minify-plugin~=0.5.0
-mkdocstrings~=0.16.2
+mkdocstrings~=0.17.0


### PR DESCRIPTION
### Update dependencies

Automatically created PR from [`ci/dependabot-updates`](https://github.com/CasperWA/turtle-canon/tree/ci/dependabot-updates).

For more information see the ["Dependabot updates" workflow](https://github.com/CasperWA/turtle-canon/blob/main/.github/workflows/ci_dependabot.yml).