### PR TITLE
Update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     exclude: ^.*\.ttl$
 
 - repo: https://github.com/ambv/black
-  rev: 21.12b0
+  rev: 22.1.0
   hooks:
   - id: black
     args:

--- a/tasks.py
+++ b/tasks.py
@@ -232,7 +232,7 @@ def update_pytest_reqs(_):
         for line in handle.readlines():
             for plugin in plugins:
                 dependency = re.match(
-                    fr"^{plugin}~=(?P<version>[0-9]+(\.[0-9]+){{1,2}}).*", line
+                    rf"^{plugin}~=(?P<version>[0-9]+(\.[0-9]+){{1,2}}).*", line
                 )
                 if not dependency:
                     continue

--- a/tests/test_canon.py
+++ b/tests/test_canon.py
@@ -93,7 +93,7 @@ def test_export_ontology(top_dir: "Path", tmp_dir: "Path") -> None:
     rdflib_canonized_dir = top_dir / "tests" / "static" / "rdflib_canonized"
 
     for rdflib_version_turtle_file in rdflib_canonized_dir.glob("*.ttl"):
-        if re.match(fr".*_{rdflib_version}$", rdflib_version_turtle_file.stem):
+        if re.match(rf".*_{rdflib_version}$", rdflib_version_turtle_file.stem):
             turtle_file = rdflib_version_turtle_file
             break
     else:


### PR DESCRIPTION
### Update dependencies

Automatically created PR from [`ci/dependabot-updates`](https://github.com/CasperWA/turtle-canon/tree/ci/dependabot-updates).

For more information see the ["Dependabot updates" workflow](https://github.com/CasperWA/turtle-canon/blob/main/.github/workflows/ci_dependabot.yml).