### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Fetch PR body
       id: pr_body
-      uses: chuhlomin/render-template@v1.6
+      uses: chuhlomin/render-template@v1.7
       with:
         template: .github/utils/single_dependency_pr_body.txt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     exclude: ^tests/.*$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.2.0
+  rev: v1.3.0
   hooks:
   - id: mypy
     exclude: ^tests/.*$


### PR DESCRIPTION
### Update dependencies

Automatically created PR from [`ci/dependabot-updates`](https://github.com/CasperWA/turtle-canon/tree/ci/dependabot-updates).

For more information see the ["Dependabot updates" workflow](https://github.com/CasperWA/turtle-canon/blob/main/.github/workflows/ci_dependabot.yml).