### PR TITLE
Add new canonized test files

### DIFF
--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -21,7 +21,7 @@ jobs:
         RDFLIB_VERSION="$(python -c 'import rdflib; print(rdflib.__version__)')"
         CANONIZED_FILENAME="turtle_canon_tests_canonized_${RDFLIB_VERSION}.ttl"
         CANONIZED_FILEPATH="${{ github.workspace }}/tests/static/rdflib_canonized/${CANONIZED_FILENAME}"
-        CORE_TEST_ONTOLOGY_FILE="${{ github.workspace }}/tests/static/rdflib_canon_tests.ttl"
+        CORE_TEST_ONTOLOGY_FILE="${{ github.workspace }}/tests/static/turtle_canon_tests.ttl"
 
         if [ -f "${CANONIZED_FILEPATH}" ]; then
           echo "Canonized test file for RDFlib version ${RDFLIB_VERSION} already exists, checking contents..."

--- a/tests/static/rdflib_canonized/turtle_canon_tests_canonized_6.3.0.ttl
+++ b/tests/static/rdflib_canonized/turtle_canon_tests_canonized_6.3.0.ttl
@@ -1,0 +1,30 @@
+@prefix : <http://www.semanticweb.org/caspera/ontologies/2021/11/untitled-ontology-43#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://example.org/turtle-canon/tests> a owl:Ontology ;
+    rdfs:comment """Test ontology file.
+
+Created by: Casper Welzel Andersen.
+
+Meant to be used for testing the Turtle Canon package (`turtle-canon`)."""@en ;
+    owl:versionIRI <http://example.org/turtle-canon/tests/1.0.0> ;
+    owl:versionInfo "1.0.0"@en .
+
+:AAA a owl:Class .
+
+:AabA a owl:Class .
+
+:AbA a owl:Class .
+
+:_test a owl:Class .
+
+:aAbA a owl:Class .
+
+:aBc a owl:Class .
+
+:bbA a owl:Class ;
+    rdfs:subClassOf :aaa .
+
+:aaa a owl:Class .
+

--- a/tests/static/rdflib_canonized/turtle_canon_tests_canonized_7.1.0.ttl
+++ b/tests/static/rdflib_canonized/turtle_canon_tests_canonized_7.1.0.ttl
@@ -1,0 +1,30 @@
+@prefix : <http://www.semanticweb.org/caspera/ontologies/2021/11/untitled-ontology-43#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://example.org/turtle-canon/tests> a owl:Ontology ;
+    rdfs:comment """Test ontology file.
+
+Created by: Casper Welzel Andersen.
+
+Meant to be used for testing the Turtle Canon package (`turtle-canon`)."""@en ;
+    owl:versionIRI <http://example.org/turtle-canon/tests/1.0.0> ;
+    owl:versionInfo "1.0.0"@en .
+
+:AAA a owl:Class .
+
+:AabA a owl:Class .
+
+:AbA a owl:Class .
+
+:_test a owl:Class .
+
+:aAbA a owl:Class .
+
+:aBc a owl:Class .
+
+:bbA a owl:Class ;
+    rdfs:subClassOf :aaa .
+
+:aaa a owl:Class .
+

--- a/tests/static/rdflib_canonized/turtle_canon_tests_canonized_7.1.1.ttl
+++ b/tests/static/rdflib_canonized/turtle_canon_tests_canonized_7.1.1.ttl
@@ -1,0 +1,30 @@
+@prefix : <http://www.semanticweb.org/caspera/ontologies/2021/11/untitled-ontology-43#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://example.org/turtle-canon/tests> a owl:Ontology ;
+    rdfs:comment """Test ontology file.
+
+Created by: Casper Welzel Andersen.
+
+Meant to be used for testing the Turtle Canon package (`turtle-canon`)."""@en ;
+    owl:versionIRI <http://example.org/turtle-canon/tests/1.0.0> ;
+    owl:versionInfo "1.0.0"@en .
+
+:AAA a owl:Class .
+
+:AabA a owl:Class .
+
+:AbA a owl:Class .
+
+:_test a owl:Class .
+
+:aAbA a owl:Class .
+
+:aBc a owl:Class .
+
+:bbA a owl:Class ;
+    rdfs:subClassOf :aaa .
+
+:aaa a owl:Class .
+


### PR DESCRIPTION
Fix typo in CI workflow.

## Copilot summary

This pull request includes updates to the CI workflow and the addition of new test ontology files for different versions of RDFlib. The most important changes are listed below:

### CI Workflow Update:
* [`.github/workflows/ci_automerge_dependabot.yml`](diffhunk://#diff-f77ed308038b0760d0f835e1a5dd676368ce483ee060053f57d12a11cdb16d58L24-R24): Updated the `CORE_TEST_ONTOLOGY_FILE` path to reflect the new filename `turtle_canon_tests.ttl`.

### Test Ontology Files Addition:
* [`tests/static/rdflib_canonized/turtle_canon_tests_canonized_6.3.0.ttl`](diffhunk://#diff-80e21c8356d2ad90954983bbaa0e094536585ec3814097985db541aeb8f24e37R1-R30): Added a new test ontology file for RDFlib version 6.3.0.
* [`tests/static/rdflib_canonized/turtle_canon_tests_canonized_7.1.0.ttl`](diffhunk://#diff-80e21c8356d2ad90954983bbaa0e094536585ec3814097985db541aeb8f24e37R1-R30): Added a new test ontology file for RDFlib version 7.1.0.
* [`tests/static/rdflib_canonized/turtle_canon_tests_canonized_7.1.1.ttl`](diffhunk://#diff-80e21c8356d2ad90954983bbaa0e094536585ec3814097985db541aeb8f24e37R1-R30): Added a new test ontology file for RDFlib version 7.1.1.