### PR TITLE
Move changes to dedicated file

### DIFF
--- a/.github/utils/canonize_rdflib_test_file.sh
+++ b/.github/utils/canonize_rdflib_test_file.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+if [ -z "${CI}" ]; then
+    echo "This script is intended to be run in a GitHub Actions environment."
+    exit 1
+else
+    echo "Running in CI environment"
+    echo "GITHUB_WORKSPACE: ${GITHUB_WORKSPACE}"
+    echo "GITHUB_ACTOR: ${GITHUB_ACTOR}"
+fi
+
+# Only run if the PR is from dependabot
+if [ "${GITHUB_ACTOR}" != "dependabot[bot]" ]; then
+    echo "This PR is not from dependabot, exiting early..."
+    exit 0
+fi
+
+pip install --upgrade pip
+pip install -U setuptools wheel
+pip install -U ${GITHUB_WORKSPACE}
+
+RDFLIB_VERSION="$(python -c 'import rdflib; print(rdflib.__version__)')"
+CANONIZED_FILENAME="turtle_canon_tests_canonized_${RDFLIB_VERSION}.ttl"
+CANONIZED_FILEPATH="${GITHUB_WORKSPACE}/tests/static/rdflib_canonized/${CANONIZED_FILENAME}"
+CORE_TEST_ONTOLOGY_FILE="${GITHUB_WORKSPACE}/tests/static/turtle_canon_tests.ttl"
+
+if [ -f "${CANONIZED_FILEPATH}" ]; then
+    echo "Canonized test file for RDFlib version ${RDFLIB_VERSION} already exists, checking contents..."
+
+    # Copy core test ontology file into a temporary file and canonize it
+    TEMP_FILEPATH="/tmp/${CANONIZED_FILENAME}.ttl"
+    cp "${CORE_TEST_ONTOLOGY_FILE}" "${TEMP_FILEPATH}"
+    turtle-canon "${TEMP_FILEPATH}"
+
+    if [ "$(diff "${TEMP_FILEPATH}" "${CANONIZED_FILEPATH}")" ]; then
+        echo "The existing canonized test file for RDFlib version ${RDFLIB_VERSION} differs from the currently generated one using the same version !"
+        rm -f "${TEMP_FILEPATH}"
+        exit 1
+    else
+        echo "Canonized test file for RDFlib version ${RDFLIB_VERSION} is up-to-date, nothing to do."
+        rm -f "${TEMP_FILEPATH}"
+        exit 0
+    fi
+else
+    echo "No canonized test file for RDFlib version ${RDFLIB_VERSION} found, creating it..."
+
+    cp "${CORE_TEST_ONTOLOGY_FILE}" "${CANONIZED_FILEPATH}"
+    turtle-canon "${CANONIZED_FILEPATH}"
+    exit 0
+fi

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -13,45 +13,6 @@ jobs:
       perform_changes: true
       git_username: CasperWA
       git_email: "casper.w.andersen@sintef.no"
-      changes: |
-        # Only run if the PR is from dependabot
-        if [ "${{ github.actor }}" != "dependabot[bot]" ]; then
-          echo "This PR is not from dependabot, exiting early..."
-          exit 0
-        fi
-
-        pip install --upgrade pip
-        pip install -U setuptools wheel
-        pip install -U .
-
-        RDFLIB_VERSION="$(python -c 'import rdflib; print(rdflib.__version__)')"
-        CANONIZED_FILENAME="turtle_canon_tests_canonized_${RDFLIB_VERSION}.ttl"
-        CANONIZED_FILEPATH="${{ github.workspace }}/tests/static/rdflib_canonized/${CANONIZED_FILENAME}"
-        CORE_TEST_ONTOLOGY_FILE="${{ github.workspace }}/tests/static/turtle_canon_tests.ttl"
-
-        if [ -f "${CANONIZED_FILEPATH}" ]; then
-          echo "Canonized test file for RDFlib version ${RDFLIB_VERSION} already exists, checking contents..."
-
-          # Copy core test ontology file into a temporary file and canonize it
-          TEMP_FILEPATH="/tmp/${CANONIZED_FILENAME}.ttl"
-          cp "${CORE_TEST_ONTOLOGY_FILE}" "${TEMP_FILEPATH}"
-          turtle-canon "${TEMP_FILEPATH}"
-
-          if [ "$(diff "${TEMP_FILEPATH}" "${CANONIZED_FILEPATH}")" ]; then
-            echo "The existing canonized test file for RDFlib version ${RDFLIB_VERSION} differs from the currently generated one using the same version !"
-            rm -f "${TEMP_FILEPATH}"
-            exit 1
-          else
-            echo "Canonized test file for RDFlib version ${RDFLIB_VERSION} is up-to-date, nothing to do."
-            rm -f "${TEMP_FILEPATH}"
-            exit 0
-          fi
-        else
-          echo "No canonized test file for RDFlib version ${RDFLIB_VERSION} found, creating it..."
-
-          cp "${CORE_TEST_ONTOLOGY_FILE}" "${CANONIZED_FILEPATH}"
-          turtle-canon "${CANONIZED_FILEPATH}"
-          exit 0
-        fi
+      changes: .github/utils/canonize_rdflib_test_file.sh
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Copilot summary

This pull request includes changes to streamline the process for handling RDFlib test files in a GitHub Actions environment. The main changes involve moving the logic for canonizing RDFlib test files into a separate script and updating the workflow configuration to use this script.

### Script and Workflow Updates:

* Added a new script `canonize_rdflib_test_file.sh` to handle the canonization of RDFlib test files. This script checks if it is running in a CI environment, verifies if the PR is from dependabot, installs necessary packages, and either checks or creates the canonized test file based on the RDFlib version.
* Updated the `ci_automerge_dependabot.yml` workflow to use the new `canonize_rdflib_test_file.sh` script for handling RDFlib test file canonization, replacing the inline script previously used.