### PR TITLE
Add a shebang to `changes`

### DIFF
--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -13,6 +13,9 @@ jobs:
       perform_changes: true
       git_username: CasperWA
       git_email: "casper.w.andersen@sintef.no"
-      changes: .github/utils/canonize_rdflib_test_file.sh
+      changes: |
+        #!/bin/bash
+
+        ./.github/utils/canonize_rdflib_test_file.sh
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -15,9 +15,8 @@ jobs:
       # General setup
       install_extras: "[dev]"
 
-      # pre-commit
-      run_pre-commit: true
-      python_version_pre-commit: "3.10"
+      # pre-commit (use pre-commit.ci)
+      run_pre-commit: false
 
       # pylint & safety
       python_version_pylint_safety: "3.10"


### PR DESCRIPTION
## Copilot summary

This pull request includes a modification to the `.github/workflows/ci_automerge_dependabot.yml` file to improve the execution of the `canonize_rdflib_test_file.sh` script.

* [`.github/workflows/ci_automerge_dependabot.yml`](diffhunk://#diff-f77ed308038b0760d0f835e1a5dd676368ce483ee060053f57d12a11cdb16d58L16-R19): Changed the `changes` parameter to include a bash script header and execute the `canonize_rdflib_test_file.sh` script.