### PR TITLE
Expand on supported Python version

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -93,8 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         pre-commit-version:
-          # minimum pre-commit version for turtle-canon
-          - "==1.15.0"
+          - "==1.15.0"  # minimum pre-commit version for turtle-canon
           # latest major versions
           - "~=1.0"
           - "~=2.0"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -92,18 +92,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - pre-commit-version: "==1.15.0"  # minimum pre-commit version for turtle-canon
-            python-version: "3.10"
+        pre-commit-version:
+          # minimum pre-commit version for turtle-canon
+          - "==1.15.0"
           # latest major versions
-          - pre-commit-version: "~=1.0"
-            python-version: "3.10"
-          - pre-commit-version: "~=2.0"
-            python-version: ["3.10", "3.11", "3.12", "3.13"]
-          - pre-commit-version: "~=3.0"
-            python-version: ["3.10", "3.11", "3.12", "3.13"]
-          - pre-commit-version: "~=4.0"
-            python-version: ["3.10", "3.11", "3.12", "3.13"]
+          - "~=1.0"
+          - "~=2.0"
+          - "~=3.0"
+          - "~=4.0"
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          - pre-commit-version: ["==1.15.0", "~=1.0"]
+            python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -102,8 +102,18 @@ jobs:
           - "~=4.0"
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         exclude:
-          - pre-commit-version: ["==1.15.0", "~=1.0"]
-            python-version: ["3.11", "3.12", "3.13"]
+          - pre-commit-version: "==1.15.0"
+            python-version: "3.11"
+          - pre-commit-version: "==1.15.0"
+            python-version: "3.12"
+          - pre-commit-version: "==1.15.0"
+            python-version: "3.13"
+          - pre-commit-version: "~=1.0"
+            python-version: "3.11"
+          - pre-commit-version: "~=1.0"
+            python-version: "3.12"
+          - pre-commit-version: "~=1.0"
+            python-version: "3.13"
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -49,14 +49,19 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install python dependencies
       run: |
@@ -78,7 +83,7 @@ jobs:
         flags: turtle-canon
       env:
         OS: ubuntu-latest
-        PYTHON: "3.10"
+        PYTHON: ${{ matrix.python-version }}
 
   as-pre-commit-hook:
     name: As a pre-commit hook (pre-commit ${{ matrix.pre-commit-version }})
@@ -93,15 +98,16 @@ jobs:
           - "~=1.0"
           - "~=2.0"
           - "~=3.0"
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -86,19 +86,24 @@ jobs:
         PYTHON: ${{ matrix.python-version }}
 
   as-pre-commit-hook:
-    name: As a pre-commit hook (pre-commit ${{ matrix.pre-commit-version }})
+    name: As a pre-commit hook (py ${{ matrix.python-version }}, pre-commit ${{ matrix.pre-commit-version }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        pre-commit-version:
-          - "==1.15.0"  # minimum pre-commit version for turtle-canon
+        include:
+          - pre-commit-version: "==1.15.0"  # minimum pre-commit version for turtle-canon
+            python-version: "3.10"
           # latest major versions
-          - "~=1.0"
-          - "~=2.0"
-          - "~=3.0"
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+          - pre-commit-version: "~=1.0"
+            python-version: "3.10"
+          - pre-commit-version: "~=2.0"
+            python-version: ["3.10", "3.11", "3.12", "3.13"]
+          - pre-commit-version: "~=3.0"
+            python-version: ["3.10", "3.11", "3.12", "3.13"]
+          - pre-commit-version: "~=4.0"
+            python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout repository

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   description: "Turtle Canon: A tool for canonizing Turtle (`.ttl`) ontology files."
   entry: turtle-canon
   language: python
-  language_version: python3.10
+  language_version: python3
   minimum_pre_commit_version: "1.15.0"
   require_serial: true
   files: \.ttl$

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Casper Welzel Andersen & SINTEF
+Copyright (c) 2021-2025 Casper Welzel Andersen & SINTEF
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development",
     "Topic :: Software Development :: Pre-processors",
     "Topic :: Software Development :: Testing",
@@ -31,7 +34,7 @@ classifiers = [
     "Topic :: Text Processing",
     "Topic :: Utilities",
 ]
-requires-python = ">=3.10,<3.11"
+requires-python = "~=3.10"
 dynamic = ["version"]
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,12 +76,11 @@ line-length = 88
 target-version = ['py310']
 
 [tool.pytest.ini_options]
-minversion = "7.4"
+minversion = "8.0"
 addopts = "-rs --cov=turtle_canon --cov-report=term-missing:skip-covered --no-cov-on-fail"
 filterwarnings = [
+    # Treat all warnings as errors
     "error",
-    # "ignore:.*imp module.*:DeprecationWarning",
-    # "ignore:.*invalid escape sequence.*:DeprecationWarning",
 ]
 
 [tool.mypy]
@@ -119,7 +118,6 @@ extend-select = [
 ]
 ignore = [
   "PLR",  # Design related pylint codes
-#   "B008",  # Performing function calls in argument defaults - done all the time in the CLI.
 ]
 isort.required-imports = ["from __future__ import annotations"]
 


### PR DESCRIPTION
Closes #249 

## AI summary

This pull request includes several updates to the CI configuration, pre-commit hooks, and project metadata to support multiple Python versions and improve overall compatibility. The most important changes include the addition of a matrix strategy for Python versions in the CI workflow, updates to the pre-commit hooks configuration, and adjustments to the project metadata in `pyproject.toml`.

### CI Configuration Updates:
* [`.github/workflows/ci_tests.yml`](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebR52-R64): Added a matrix strategy to test against Python versions 3.10, 3.11, 3.12, and 3.13, and updated the setup steps to use the matrix Python version. [[1]](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebR52-R64) [[2]](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL81-R125)

### Pre-commit Hooks Configuration:
* [`.pre-commit-hooks.yaml`](diffhunk://#diff-cb921d5df435fe404b4daf451cf783709ccebe9c346038af6036644e7386c13dL6-R6): Changed `language_version` to `python3` to ensure compatibility with multiple Python versions.

### Project Metadata Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R27-R37): Added classifiers for Python versions 3.11, 3.12, and 3.13, updated the required Python version specification, and increased the minimum pytest version to 8.0. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R27-R37) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L76-L81)
* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright year to 2025.

These changes enhance the compatibility and testing coverage of the project across different Python versions, ensuring better stability and future-proofing.