### PR TITLE
Publish to PyPI upon release

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -6,10 +6,12 @@ on:
     - published
 
 jobs:
-  publish-docs:
+  build:
     name: External
     uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.9.0
     if: github.repository == 'CasperWA/turtle-canon' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     with:
       # General
       git_username: CasperWA
@@ -29,6 +31,7 @@ jobs:
       build_cmd: "python -m build"
       changelog_exclude_labels: skip_changelog,duplicate,question,invalid,wontfix
       publish_on_pypi: false
+      upload_distribution: true
 
       # Documentation
       update_docs: true
@@ -39,3 +42,27 @@ jobs:
 
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: release
+      url: https://pypi.org/project/turtle-canon
+
+    # The id-token:write permission is required by the PyPI upload action for
+    # Trusted Publishers
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: dist  # The artifact will always be called 'dist'
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #253 

## AI summary

This pull request makes significant updates to the GitHub Actions workflow for continuous deployment by restructuring the jobs and adding a new job for publishing to PyPI. The most important changes include renaming and modifying existing jobs, adding permissions, and introducing a new job for publishing.

Changes to workflow jobs:

* [`.github/workflows/cd_release.yml`](diffhunk://#diff-596559b1f8b64fb202104da87bab57ea30a0902451ca9cba6826485bf30976cdL9-R14): Renamed the `publish-docs` job to `build` and added permissions for writing contents.
* [`.github/workflows/cd_release.yml`](diffhunk://#diff-596559b1f8b64fb202104da87bab57ea30a0902451ca9cba6826485bf30976cdR34): Added the `upload_distribution` parameter to the `build` job configuration.

Addition of new job:

* [`.github/workflows/cd_release.yml`](diffhunk://#diff-596559b1f8b64fb202104da87bab57ea30a0902451ca9cba6826485bf30976cdR45-R68): Introduced a new `publish` job to handle publishing to PyPI, which includes setting up the environment, permissions, and steps for downloading the distribution and publishing it.