### PR TITLE
Group GH Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,11 @@ updates:
   - CI/CD
   - skip_changelog
   groups:
-    pyproject:
+    python:
       applies-to: "version-updates"
       patterns:
         - "*"
-    pyproject-security:
+    python-security:
       applies-to: "security-updates"
       patterns:
         - "*"
@@ -31,3 +31,12 @@ updates:
   labels:
   - CI/CD
   - skip_changelog
+  groups:
+    actions:
+      applies-to: "version-updates"
+      patterns:
+        - "*"
+    actions-security:
+      applies-to: "security-updates"
+      patterns:
+        - "*"


### PR DESCRIPTION
## AI Summary

This pull request updates the Dependabot configuration to improve the grouping of dependency updates in the `.github/dependabot.yml` file. The main changes involve renaming existing groups for clarity and adding new groups for GitHub Actions dependencies.

Dependabot group improvements:

* Renamed the `pyproject` group to `python` and the `pyproject-security` group to `python-security` for better clarity and consistency in grouping Python dependencies.
* Added new groups: `actions` for version updates and `actions-security` for security updates, both targeting GitHub Actions dependencies.